### PR TITLE
Update GraphicsInterpreter.cs

### DIFF
--- a/data/GraphicsInterpreter.cs
+++ b/data/GraphicsInterpreter.cs
@@ -40,6 +40,7 @@ namespace BmLauncherAsylumNET6.data
                     {
                         if (Graphics.getLanguage() == "nochange")
                         {
+                            Program.MyFactory.LineInt = 110;
                             return lineToCheck;
                         }
 


### PR DESCRIPTION
If a language variable contained a non-standard parameter, then the remaining parameters were not saved.

